### PR TITLE
fix: curl has to know about https_proxy 

### DIFF
--- a/core/files/configure_misp.sh
+++ b/core/files/configure_misp.sh
@@ -374,7 +374,7 @@ update_ca_certificates() {
     update-ca-certificates
     # Upgrade cake cacert.pem file from Mozilla project
     echo "Updating /var/www/MISP/app/Lib/cakephp/lib/Cake/Config/cacert.pem..."
-    sudo -u www-data curl -s --etag-compare /var/www/MISP/app/Lib/cakephp/lib/Cake/Config/etag.txt --etag-save /var/www/MISP/app/Lib/cakephp/lib/Cake/Config/etag.txt https://curl.se/ca/cacert.pem -o /var/www/MISP/app/Lib/cakephp/lib/Cake/Config/cacert.pem
+    sudo -E -u www-data curl -s --etag-compare /var/www/MISP/app/Lib/cakephp/lib/Cake/Config/etag.txt --etag-save /var/www/MISP/app/Lib/cakephp/lib/Cake/Config/etag.txt https://curl.se/ca/cacert.pem -o /var/www/MISP/app/Lib/cakephp/lib/Cake/Config/cacert.pem
 }
 
 create_sync_servers() {


### PR DESCRIPTION
curl command will fail after a long timeout behind a corporate proxy.  
adding `-E` allows the user to influence this  by adding `https_proxy` environment variable to docker-compose file.